### PR TITLE
Feat: file and media support 

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,24 +2,39 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
-
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
 )
 
 const ConfigFile = "config.json"
 const LogFile = "log.txt"
 
+const defaultTempDir = "./temp"
+
 type Config struct {
 	Port     string       `json:"port"`
 	LogLevel logrus.Level `json:"logLevel"`
+	TempDir  *string      `json:"tempDir"`
+}
+
+func (c *Config) GetTempDir() string {
+	if c.TempDir == nil {
+		return defaultTempDir
+	}
+
+	return *c.TempDir
 }
 
 var DefaultConfig = Config{
 	Port:     "8086",
 	LogLevel: log.WarnLevel,
+	TempDir:  ToPtrString(defaultTempDir),
+}
+
+func ToPtrString(str string) *string {
+	return &str
 }
 
 func loadConfig(path string) (*Config, error) {

--- a/server.go
+++ b/server.go
@@ -98,14 +98,14 @@ func setHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		_, _ = io.Copy(file, rd)
 
 		if contentType == typeMedia {
-			notify = "[图片媒体] 路径已复制到剪贴板"
+			notify = "[图片媒体] 已复制到剪贴板"
 		} else {
-			notify = "[文件] 路径已复制到剪贴板"
+			notify = "[文件] 已复制到剪贴板"
 		}
 
 		setLastFilename(filename)
 
-		if err := walk.Clipboard().SetText(path); err != nil {
+		if err := utils.Clipboard().SetFile(path); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			requestLogger.WithError(err).Warn("failed to set clipboard")
 			return

--- a/utils/clipboard.go
+++ b/utils/clipboard.go
@@ -1,0 +1,171 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"github.com/lxn/walk"
+	"github.com/lxn/win"
+	"syscall"
+	"unsafe"
+)
+
+var clipboard ClipboardService
+
+// Clipboard returns an object that provides access to the system clipboard.
+func Clipboard() *ClipboardService {
+	return &clipboard
+}
+
+// ClipboardService provides access to the system clipboard.
+type ClipboardService struct {
+	hwnd                     win.HWND
+	contentsChangedPublisher walk.EventPublisher
+}
+
+// ContentsChanged returns an Event that you can attach to for handling
+// clipboard content changes.
+func (c *ClipboardService) ContentsChanged() *walk.Event {
+	return c.contentsChangedPublisher.Event()
+}
+
+// Clear clears the contents of the clipboard.
+func (c *ClipboardService) Clear() error {
+	return c.withOpenClipboard(func() error {
+		if !win.EmptyClipboard() {
+			return lastError("EmptyClipboard")
+		}
+
+		return nil
+	})
+}
+
+// ContainsText returns whether the clipboard currently contains text data.
+func (c *ClipboardService) ContainsText() (available bool, err error) {
+	err = c.withOpenClipboard(func() error {
+		available = win.IsClipboardFormatAvailable(win.CF_UNICODETEXT)
+
+		return nil
+	})
+
+	return
+}
+
+// Text returns the current text data of the clipboard.
+func (c *ClipboardService) Text() (text string, err error) {
+	err = c.withOpenClipboard(func() error {
+		hMem := win.HGLOBAL(win.GetClipboardData(win.CF_UNICODETEXT))
+		if hMem == 0 {
+			return lastError("GetClipboardData")
+		}
+
+		p := win.GlobalLock(hMem)
+		if p == nil {
+			return lastError("GlobalLock()")
+		}
+		defer win.GlobalUnlock(hMem)
+
+		text = win.UTF16PtrToString((*uint16)(p))
+
+		return nil
+	})
+
+	return
+}
+
+// SetText sets the current text data of the clipboard.
+func (c *ClipboardService) SetText(s string) error {
+	return c.withOpenClipboard(func() error {
+		utf16, err := syscall.UTF16FromString(s)
+		if err != nil {
+			return err
+		}
+
+		hMem := win.GlobalAlloc(win.GMEM_MOVEABLE, uintptr(len(utf16)*2))
+		if hMem == 0 {
+			return lastError("GlobalAlloc")
+		}
+
+		p := win.GlobalLock(hMem)
+		if p == nil {
+			return lastError("GlobalLock()")
+		}
+
+		win.MoveMemory(p, unsafe.Pointer(&utf16[0]), uintptr(len(utf16)*2))
+
+		win.GlobalUnlock(hMem)
+
+		if 0 == win.SetClipboardData(win.CF_UNICODETEXT, win.HANDLE(hMem)) {
+			// We need to free hMem.
+			defer win.GlobalFree(hMem)
+
+			return lastError("SetClipboardData")
+		}
+
+		// The system now owns the memory referred to by hMem.
+
+		return nil
+	})
+}
+
+type DROPFILES struct {
+	pFiles uintptr
+	pt     uintptr
+	fNC    bool
+	fWide  bool
+}
+
+// SetFile sets the current file drop data of the clipboard.
+func (c *ClipboardService) SetFile(s string) error {
+	return c.withOpenClipboard(func() error {
+		utf16, err := syscall.UTF16FromString(s)
+		if err != nil {
+			return err
+		}
+
+		size := unsafe.Sizeof(DROPFILES{}) + uintptr((len(utf16)+2)*2)
+
+		hMem := win.GlobalAlloc(win.GMEM_MOVEABLE, size)
+		if hMem == 0 {
+			return lastError("GlobalAlloc")
+		}
+
+		p := win.GlobalLock(hMem)
+		if p == nil {
+			return lastError("GlobalLock()")
+		}
+
+		zeroMem := make([]byte, size)
+		win.MoveMemory(p, unsafe.Pointer(&zeroMem[0]), size)
+
+		pD := (*DROPFILES)(p)
+		pD.pFiles = unsafe.Sizeof(DROPFILES{})
+		pD.fWide = true
+		win.MoveMemory(unsafe.Pointer(uintptr(p)+unsafe.Sizeof(DROPFILES{})), unsafe.Pointer(&utf16[0]), uintptr(len(utf16)*2))
+
+		win.GlobalUnlock(hMem)
+
+		if 0 == win.SetClipboardData(win.CF_HDROP, win.HANDLE(hMem)) {
+			// We need to free hMem.
+			defer win.GlobalFree(hMem)
+
+			return lastError("SetClipboardData")
+		}
+
+		// The system now owns the memory referred to by hMem.
+
+		return nil
+	})
+}
+
+func (c *ClipboardService) withOpenClipboard(f func() error) error {
+	if !win.OpenClipboard(c.hwnd) {
+		return lastError("OpenClipboard")
+	}
+	defer win.CloseClipboard()
+
+	return f()
+}
+
+func lastError(name string) error {
+	return errors.New(fmt.Sprintf("%s failed", name))
+}

--- a/utils/string.go
+++ b/utils/string.go
@@ -1,0 +1,13 @@
+package utils
+
+import "math/rand"
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
小改了一下，支持了文件和图片媒体粘贴

需要快捷指令支持，example:
https://www.icloud.com/shortcuts/8d2e6c875b294ec080e03c3db90b07bc

小改了一下顺便做了个共享表单支持

链接格式为: http://<地址>?version=<版本号>&type=<类型>&filename=<文件名>

---

我看了一下用的walk的库似乎只支持text格式的剪贴板操作，所以现在有两个方案
一是给walk上游库提交PR支持更多格式
二是独立出来自己实现操作剪贴板 (已实现

~~不过看起来有点麻烦就先放放 :)~~

另外可以考虑增加一项authkey简单的防止未授权访问