### PR TITLE
feat: add powershell build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ clipboard-online is an application to share cilpboard text between Windows and i
     - `cd clipboard-online`
     - `go get github.com/akavel/rsrc`
     - `./build.sh`
+      - PowerShell：`.\build.ps1`
     - You can find release bin at `release` directory
 
 ## Usage

--- a/README_zh.md
+++ b/README_zh.md
@@ -25,6 +25,7 @@ clipboard-online 是一款可以帮你在 💻Windows 和 📱iOS 之间分享�
     - `cd clipboard-online`
     - `go get github.com/akavel/rsrc`
     - `./build.sh`
+      - PowerShell：`.\build.ps1`
     - 你可以在 `release` 目录下找到可执行文件
 
 ## 使用

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    build script
+#>
+
+
+param (
+    [string]$version = "",
+    [Switch]$debug
+)
+
+
+Set-Location -Path $(Split-Path -Parent $MyInvocation.MyCommand.Definition)
+
+
+$ROOT = $PWD
+$prog = $($(Select-String module go.mod) -replace '.*?/')
+$RELEASE_DIR = "${ROOT}\release"
+$ENV_GOAPTH = $(go env GOPATH)
+$output="${RELEASE_DIR}/$prog.exe"
+$mode = "release"
+
+if ($version -eq "") {
+    git describe --exact-match 2>$null
+    if ($?) {
+        $version = $(git describe --tags --abbrev=0)
+    }
+    else {
+        $version = $(git log --pretty=format:'%h' -1)
+    }
+
+}
+
+
+if ($debug) {
+    $mode = "debug"
+}
+
+function build() {
+    & $ENV_GOAPTH/bin/rsrc.exe -manifest clipboard-online.manifest -ico app.ico -o rsrc.syso
+    if ( $mode -eq "debug") {
+        build_debug
+    }
+    else {
+        build_release
+        Write-Output "Build complete"
+    }
+}
+  
+function build_debug() {
+    Write-Output "build: debug"
+    go build -ldflags="-X 'main.mode=$mode' -X 'main.version=$version'" -o $output
+}
+
+function build_release() {
+    Write-Output "build: release"
+    go build -ldflags="-s -w -H windowsgui -X 'main.mode=$mode' -X 'main.version=$version'" -o $output
+}
+  
+# Start build
+build


### PR DESCRIPTION
把`build.sh`翻译成了`build.ps1`，方便习惯用PowerShell的人。

顺便安利下PowerShell :smile:

允许执行第三方脚本可能要用管理员执行下`Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Confirm`。